### PR TITLE
Allow to exclude robots.txt file from generation, add tests, fix typos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,14 @@ Last modification option for sitemap.
 - **Type:** `boolean`
 - **Default:** `false`
 
-Converts XML into a human readable format
+Converts XML into a human-readable format
+
+### generateRobotsTxt
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Enables robots.txt file generation
 
 ### robots
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,8 @@ import type { ResolvedOptions, UserOptions } from './types'
 export function generateSitemap(options: UserOptions = {}) {
   const resolvedOptions: ResolvedOptions = resolveOptions(options)
 
+  // robots.txt
   if (resolvedOptions.generateRobotsTxt) {
-    // robots.txt
     const robotRules = getRules(resolvedOptions.robots)
     const robotContent = getContent(robotRules, resolvedOptions.hostname)
     writeFileSync(getResolvedPath('robots.txt', resolvedOptions), robotContent)

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,10 +10,13 @@ import type { ResolvedOptions, UserOptions } from './types'
 
 export function generateSitemap(options: UserOptions = {}) {
   const resolvedOptions: ResolvedOptions = resolveOptions(options)
-  // robots.txt
-  const robotRules = getRules(resolvedOptions.robots)
-  const robotContent = getContent(robotRules, resolvedOptions.hostname)
-  writeFileSync(getResolvedPath('robots.txt', resolvedOptions), robotContent)
+
+  if (resolvedOptions.generateRobotsTxt) {
+    // robots.txt
+    const robotRules = getRules(resolvedOptions.robots)
+    const robotContent = getContent(robotRules, resolvedOptions.hostname)
+    writeFileSync(getResolvedPath('robots.txt', resolvedOptions), robotContent)
+  }
 
   // sitemap.xml
   const routes = getRoutes(resolvedOptions)

--- a/src/options.ts
+++ b/src/options.ts
@@ -13,6 +13,7 @@ export function resolveOptions(userOptions: UserOptions): ResolvedOptions {
       priority: 1,
       lastmod: new Date(),
       readable: false,
+      generateRobotsTxt: true,
       robots: [{
         userAgent: '*',
         allow: '/',

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,10 +80,15 @@ interface Options {
    */
   lastmod: Date
   /**
-   * Converts XML into a human readable format
+   * Converts XML into a human-readable format
    * @default false
    */
   readable: boolean
+  /**
+   * Enables robots.txt file generation
+   * @default true
+   */
+  generateRobotsTxt: boolean
   /**
    * Robots policy
    * @default [{ userAgent: '*', allow: '/' }]

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -10,8 +10,12 @@ describe('Index', () => {
     expect(existsSync(SITEMAP_FILE)).toBe(false)
     expect(existsSync(ROBOTS_FILE)).toBe(false)
 
-    generateSitemap()
+    generateSitemap({ generateRobotsTxt: false })
 
+    expect(existsSync(SITEMAP_FILE)).toBe(false)
+    expect(existsSync(ROBOTS_FILE)).toBe(false)
+
+    generateSitemap()
     expect(existsSync(SITEMAP_FILE)).toBe(false)
     expect(existsSync(ROBOTS_FILE)).toBe(true)
 

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -12,6 +12,7 @@ describe('Options', () => {
         "dynamicRoutes": [],
         "exclude": [],
         "extensions": "html",
+        "generateRobotsTxt": true,
         "hostname": "http://localhost/",
         "lastmod": Any<Date>,
         "outDir": "dist",
@@ -42,6 +43,7 @@ describe('Options', () => {
           "/route2/sub-route",
         ],
         "extensions": "html",
+        "generateRobotsTxt": true,
         "hostname": "http://localhost/",
         "lastmod": Any<Date>,
         "outDir": "dist",
@@ -72,6 +74,7 @@ describe('Options', () => {
           "html",
           "md",
         ],
+        "generateRobotsTxt": true,
         "hostname": "http://localhost/",
         "lastmod": Any<Date>,
         "outDir": "dist",
@@ -110,6 +113,7 @@ describe('Options', () => {
         "dynamicRoutes": [],
         "exclude": [],
         "extensions": "html",
+        "generateRobotsTxt": true,
         "hostname": "http://localhost/",
         "lastmod": Any<Date>,
         "outDir": "dist",
@@ -133,6 +137,34 @@ describe('Options', () => {
               "/another-disabled-path",
             ],
             "userAgent": "GoogleBot",
+          },
+        ],
+      }
+    `)
+  })
+
+  test('resolve options with disabled robots.txt file', () => {
+    expect(resolveOptions({
+      generateRobotsTxt: false,
+    })).toMatchInlineSnapshot({
+      lastmod: expect.any(Date),
+    }, `
+      {
+        "basePath": "",
+        "changefreq": "daily",
+        "dynamicRoutes": [],
+        "exclude": [],
+        "extensions": "html",
+        "generateRobotsTxt": false,
+        "hostname": "http://localhost/",
+        "lastmod": Any<Date>,
+        "outDir": "dist",
+        "priority": 1,
+        "readable": false,
+        "robots": [
+          {
+            "allow": "/",
+            "userAgent": "*",
           },
         ],
       }


### PR DESCRIPTION
I use `vite-ssg-sitemap` library, which is based on `sitemap-ts` library. I was surprised when I discovered that my own robots.txt file was replaced with some other file. After investigation, I realized your library not only provides the sitemap generation but also automatically creates a robots.txt file, which is really cool for those who are not familiar with SEO basics. However, there is no way to disable that generation, so I decided to add that option, with remained `true` (enabled) value by default.

robots.txt file is actually something that you don't change that much - you mainly copy/paste that file from old projects, so for me, it's easier to just put that file in the public folder and don't generate it on each build. That's the main reason for disabling that generation. Moreover, I didn't find some options that I want to add to robots.txt file (they are non-standard, btw) - so a manual fix is required anyway.

BTW, since I [encountered some issues](https://github.com/jbaubree/sitemap-ts/issues/72) with my IDE/config file, please check my MR locally before merging.