### PR TITLE
feature: changefreq, priority, lastmod changeable by route

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,24 +78,31 @@ Example: ['html', 'md']
 
 ### changefreq
 
-- **Type:** `string`
+- **Type:** `string | RoutesOptionMap<string>`
 - **Default:** `'daily'`
 
 Change frequency option for sitemap.
 
 ### priority
 
-- **Type:** `number`
+- **Type:** `number | RoutesOptionMap<number>`
 - **Default:** `1`
 
 Priority option for sitemap.
 
 ### lastmod
 
-- **Type:** `Date`
+- **Type:** `Date | RoutesOptionMap<Date>`
 - **Default:** `new Date()`
 
 Last modification option for sitemap.
+
+### RoutesOptionMap\<Type>
+
+- **Type:** `{ [route: string]: Type }`
+
+Used for changing `changefreq`, `priority`, or `lastmod` on a by-route level.
+The (optional) route `'*'` is used as default.
 
 ### readable
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,24 +1,27 @@
 import type { ResolvedOptions, UserOptions } from './types'
 
+export const defaultOptions = {
+  hostname: 'http://localhost/',
+  dynamicRoutes: [],
+  exclude: [],
+  basePath: '',
+  outDir: 'dist',
+  extensions: 'html',
+  changefreq: 'daily',
+  priority: 1,
+  lastmod: new Date(),
+  readable: false,
+  generateRobotsTxt: true,
+  robots: [{
+    userAgent: '*',
+    allow: '/',
+  }],
+}
+
 export function resolveOptions(userOptions: UserOptions): ResolvedOptions {
   return Object.assign(
-    {
-      hostname: 'http://localhost/',
-      dynamicRoutes: [],
-      exclude: [],
-      basePath: '',
-      outDir: 'dist',
-      extensions: 'html',
-      changefreq: 'daily',
-      priority: 1,
-      lastmod: new Date(),
-      readable: false,
-      generateRobotsTxt: true,
-      robots: [{
-        userAgent: '*',
-        allow: '/',
-      }],
-    },
+    {},
+    defaultOptions,
     userOptions,
   )
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,8 @@ export interface RobotOption {
   cleanParam?: string
 }
 
+export type RoutesOptionMap<T> = T | { [key: string]: T }
+
 /**
  * Plugin options.
  */
@@ -68,17 +70,17 @@ interface Options {
    * Change frequency option for sitemap
    * @default 'daily'
    */
-  changefreq: string
+  changefreq: string | RoutesOptionMap<string>
   /**
    * Priority option for sitemap
    * @default 1
    */
-  priority: number
+  priority: number | RoutesOptionMap<number>
   /**
    * Last modification option for sitemap
    * @default new Date()
    */
-  lastmod: Date
+  lastmod: Date | RoutesOptionMap<Date>
   /**
    * Converts XML into a human-readable format
    * @default false

--- a/test/sitemap.test.ts
+++ b/test/sitemap.test.ts
@@ -78,5 +78,41 @@ describe('Sitemap', () => {
         },
       ]
     `)
+    expect(getFormattedSitemap(resolveOptions({ changefreq: 'monthly', priority: 0.7 }), ['/route'])).toMatchInlineSnapshot([{
+      lastmod: expect.any(Date),
+    }], `
+      [
+        {
+          "changefreq": "monthly",
+          "lastmod": Any<Date>,
+          "priority": 0.7,
+          "url": "http://localhost/route",
+        },
+      ]
+    `)
+    expect(getFormattedSitemap(resolveOptions({ changefreq: { '*': 'weekly', '/otherRoute': 'monthly' }, priority: { '*': 0.8, '/otherRoute': 0.4 } }), ['/route'])).toMatchInlineSnapshot([{
+      lastmod: expect.any(Date),
+    }], `
+      [
+        {
+          "changefreq": "weekly",
+          "lastmod": Any<Date>,
+          "priority": 0.8,
+          "url": "http://localhost/route",
+        },
+      ]
+    `)
+    expect(getFormattedSitemap(resolveOptions({ changefreq: { '*': 'weekly', '/route': 'monthly', '/otherRoute': 'never' }, priority: { '*': 0.8, '/route': 0.6, '/otherRoute': 0.5 } }), ['/route'])).toMatchInlineSnapshot([{
+      lastmod: expect.any(Date),
+    }], `
+      [
+        {
+          "changefreq": "monthly",
+          "lastmod": Any<Date>,
+          "priority": 0.6,
+          "url": "http://localhost/route",
+        },
+      ]
+    `)
   })
 })


### PR DESCRIPTION
Using the vite-plugin-sitemap, I wanted the ability to give some routes/pages a different priority than others. This pull request adds this ability, although it would have to travel upstream to be useful in the plugin.
Being backwards compatible, it is still possible to use it as before. But now the `priority` option can be given a number (as before) as well as an object. The object maps routes to their respective priorities, the route being the key and the priority being the value. It is not needed to include every single route in the mapping object. A user can define the `'*'` route/key to be used as the default. Every route that is not mapped, will get the value of the `'*'` route. If the `'*'` route is missing, it will use the hardcoded default from options.ts. Superfluous route mappings are ignored.
Since this was easily extendible to the `changefreq` and `lastmod` options as well, they work in the same way.

The reason for changing options.ts and pulling out the object with default values, is such that those default values can be easily accessed, keeping everything DRY.

I included tests for `changefreq` and `priority`, skipping `lastmod` because Dates are annoying.
I also updated the readme to reflect these changes.

If the implementation is lacking or should be done differently, please let me know, I'm very willing to adapt it.
If on the other hand this feature is not wanted, that would be a shame imo, as I do believe it to be valuable.