### PR TITLE
Implement i18n option for path prefix/suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,12 +128,12 @@ Converts XML into a human-readable format
 
 ### i18n
 
-- **Type:** `{ defaultLanguage?: string, languages: string[], pathPrefix?: boolean }`
-- **Default:** `undefined, pathPrefix: false`
+- **Type:** `{ defaultLanguage?: string, languages: string[], strategy?: 'suffix' | 'prefix' }`
+- **Default:** `undefined, strategy: 'suffix'`
 
 Add i18n support defining alternate links.
-defaultLanguage will use this language with / and languages with /language
-pathPrefix specifies if the language code is a prefix to the path or suffix. Suffix is default. Example: http://localhost/mypage/en or http://localhost/en/mypage
+defaultLanguage will use this language with / and languages with /language.
+strategy specifies if the language code is a suffix to the path or a prefix. 'suffix' is default. Example: http://localhost/mypage/en or http://localhost/en/mypage
 
 ### generateRobotsTxt
 

--- a/README.md
+++ b/README.md
@@ -128,11 +128,12 @@ Converts XML into a human-readable format
 
 ### i18n
 
-- **Type:** `{ defaultLanguage?: string, languages: string[] }`
-- **Default:** `undefined`
+- **Type:** `{ defaultLanguage?: string, languages: string[], pathPrefix?: boolean }`
+- **Default:** `undefined, pathPrefix: false`
 
 Add i18n support defining alternate links.
 defaultLanguage will use this language with / and languages with /language
+pathPrefix specifies if the language code is a prefix to the path or suffix. Suffix is default. Example: http://localhost/mypage/en or http://localhost/en/mypage
 
 ### generateRobotsTxt
 

--- a/src/sitemap.ts
+++ b/src/sitemap.ts
@@ -47,9 +47,10 @@ export function getFormattedSitemap(options: ResolvedOptions, routes: string[]) 
       lastmod: getOptionByRoute(options.lastmod, route) ?? defaultOptions.lastmod,
     }
     if (options.i18n) {
+      const strategy = options.i18n.strategy ?? 'suffix'
       const languages = options.i18n.languages.map(str => ({
         lang: str,
-        url: str === options.i18n?.defaultLanguage ? url : new URL(options.i18n?.pathPrefix ? ensurePrefix('/', str) + routePath : removeMaybeSuffix('/', routePath) + ensurePrefix('/', str), hostNamePath).href,
+        url: str === options.i18n?.defaultLanguage ? url : new URL(strategy === 'prefix' ? ensurePrefix('/', str) + routePath : removeMaybeSuffix('/', routePath) + ensurePrefix('/', str), hostNamePath).href,
       }))
       return Object.assign(formattedSitemap, { links: options.i18n.defaultLanguage ? [...languages, { lang: 'x-default', url }] : languages })
     }

--- a/src/sitemap.ts
+++ b/src/sitemap.ts
@@ -37,7 +37,9 @@ function getOptionByRoute<T extends Date | string | number>(options: T | RoutesO
 
 export function getFormattedSitemap(options: ResolvedOptions, routes: string[]) {
   return routes.map((route) => {
-    const url = new URL(options.basePath ? ensurePrefix('/', options.basePath) + ensurePrefix('/', route) : ensurePrefix('/', route), removeMaybeSuffix('/', options.hostname)).href
+    const hostNamePath = removeMaybeSuffix('/', options.hostname)
+    const routePath = options.basePath ? ensurePrefix('/', options.basePath) + ensurePrefix('/', route) : ensurePrefix('/', route)
+    const url = new URL(routePath, hostNamePath).href
     const formattedSitemap = {
       url,
       changefreq: getOptionByRoute(options.changefreq, route) ?? defaultOptions.changefreq,
@@ -47,7 +49,7 @@ export function getFormattedSitemap(options: ResolvedOptions, routes: string[]) 
     if (options.i18n) {
       const languages = options.i18n.languages.map(str => ({
         lang: str,
-        url: str === options.i18n?.defaultLanguage ? url : `${removeMaybeSuffix('/', url)}${ensurePrefix('/', str)}`,
+        url: str === options.i18n?.defaultLanguage ? url : new URL(options.i18n?.pathPrefix ? ensurePrefix('/', str) + routePath : removeMaybeSuffix('/', routePath) + ensurePrefix('/', str), hostNamePath).href,
       }))
       return Object.assign(formattedSitemap, { links: options.i18n.defaultLanguage ? [...languages, { lang: 'x-default', url }] : languages })
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,14 +54,14 @@ interface Options {
    * Example: {
    *  defaultLanguage: 'fr'
    *  languages: ['fr', 'en', 'es']
-   *  pathPrefix: true
+   *  strategy: 'suffix' | 'prefix'
    * }
-   * @default undefined, prefix: false
+   * @default undefined, strategy: 'suffix'
    */
   i18n?: {
     defaultLanguage?: string
     languages: string[]
-    pathPrefix?: boolean
+    strategy?: 'suffix' | 'prefix'
   }
   /**
    * Other sitemaps paths
@@ -120,4 +120,4 @@ interface Options {
 
 export type UserOptions = Partial<Options>
 
-export interface ResolvedOptions extends Options {}
+export interface ResolvedOptions extends Options { }

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,12 +54,14 @@ interface Options {
    * Example: {
    *  defaultLanguage: 'fr'
    *  languages: ['fr', 'en', 'es']
+   *  pathPrefix: true
    * }
-   * @default undefined
+   * @default undefined, prefix: false
    */
   i18n?: {
     defaultLanguage?: string
     languages: string[]
+    pathPrefix?: boolean
   }
   /**
    * Other sitemaps paths

--- a/test/sitemap.test.ts
+++ b/test/sitemap.test.ts
@@ -136,6 +136,50 @@ describe('sitemap', () => {
         },
       ]
     `)
+    expect(getFormattedSitemap(resolveOptions({ i18n: { languages: ['fr', 'en'], strategy: 'suffix' } }), ['/route'])).toMatchInlineSnapshot([{
+      lastmod: expect.any(Date),
+    }], `
+      [
+        {
+          "changefreq": "daily",
+          "lastmod": Any<Date>,
+          "links": [
+            {
+              "lang": "fr",
+              "url": "http://localhost/route/fr",
+            },
+            {
+              "lang": "en",
+              "url": "http://localhost/route/en",
+            },
+          ],
+          "priority": 1,
+          "url": "http://localhost/route",
+        },
+      ]
+    `)
+    expect(getFormattedSitemap(resolveOptions({ i18n: { languages: ['fr', 'en'], strategy: 'prefix' } }), ['/route'])).toMatchInlineSnapshot([{
+      lastmod: expect.any(Date),
+    }], `
+      [
+        {
+          "changefreq": "daily",
+          "lastmod": Any<Date>,
+          "links": [
+            {
+              "lang": "fr",
+              "url": "http://localhost/fr/route",
+            },
+            {
+              "lang": "en",
+              "url": "http://localhost/en/route",
+            },
+          ],
+          "priority": 1,
+          "url": "http://localhost/route",
+        },
+      ]
+    `)
     expect(getFormattedSitemap(resolveOptions({ i18n: { languages: ['fr', 'en'], defaultLanguage: 'fr' } }), ['/route'])).toMatchInlineSnapshot([{
       lastmod: expect.any(Date),
     }], `
@@ -151,6 +195,58 @@ describe('sitemap', () => {
             {
               "lang": "en",
               "url": "http://localhost/route/en",
+            },
+            {
+              "lang": "x-default",
+              "url": "http://localhost/route",
+            },
+          ],
+          "priority": 1,
+          "url": "http://localhost/route",
+        },
+      ]
+    `)
+    expect(getFormattedSitemap(resolveOptions({ i18n: { languages: ['fr', 'en'], defaultLanguage: 'fr', strategy: 'suffix' } }), ['/route'])).toMatchInlineSnapshot([{
+      lastmod: expect.any(Date),
+    }], `
+      [
+        {
+          "changefreq": "daily",
+          "lastmod": Any<Date>,
+          "links": [
+            {
+              "lang": "fr",
+              "url": "http://localhost/route",
+            },
+            {
+              "lang": "en",
+              "url": "http://localhost/route/en",
+            },
+            {
+              "lang": "x-default",
+              "url": "http://localhost/route",
+            },
+          ],
+          "priority": 1,
+          "url": "http://localhost/route",
+        },
+      ]
+    `)
+    expect(getFormattedSitemap(resolveOptions({ i18n: { languages: ['fr', 'en'], defaultLanguage: 'fr', strategy: 'prefix' } }), ['/route'])).toMatchInlineSnapshot([{
+      lastmod: expect.any(Date),
+    }], `
+      [
+        {
+          "changefreq": "daily",
+          "lastmod": Any<Date>,
+          "links": [
+            {
+              "lang": "fr",
+              "url": "http://localhost/route",
+            },
+            {
+              "lang": "en",
+              "url": "http://localhost/en/route",
             },
             {
               "lang": "x-default",


### PR DESCRIPTION
I'm using vite-plugin-sitemap and ran into the same issue as #107 or https://github.com/jbaubree/vite-ssg-sitemap/issues/749.

So I implemented the prefix/suffix behavior that was discussed in #749.

Added the optional pathPrefix option in options.i18n. It defaults to false, so that the original behavior with suffixes remain.