### PR TITLE
fix: fix package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     }
@@ -33,14 +32,6 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./dist/*",
-        "./dist/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Current CJS types being masquerading https://arethetypeswrong.github.io/?p=sitemap-ts%401.9.0

With this PR:

<img width="218" height="236" alt="image" src="https://github.com/user-attachments/assets/77d48120-9917-418c-b2ad-ee8234ec2f85" />
