### PR TITLE
feat(i18n): add `prefix_except_default` strategy

### DIFF
--- a/src/sitemap.ts
+++ b/src/sitemap.ts
@@ -120,11 +120,11 @@ function prefixExceptDefaultLanguageFactory(
           ? route.replace(locale[0], '')
           : route.replace(locale[1], '')
         if (url === '') {
-          pathWithoutLang = useBasePath[0] === '/' ? useBasePath.slice(1) : useBasePath
+          pathWithoutLang = useBasePath.slice(1)
           url = ensureSuffix('/', new URL(`${useBasePath}${locale[2]}`, hostNamePath).href)
         }
         else {
-          pathWithoutLang = url.replace(useBasePath, '')
+          pathWithoutLang = url[0] === '/' ? url.slice(1) : url
           url = new URL(route, hostNamePath).href
         }
       }
@@ -138,21 +138,23 @@ function prefixExceptDefaultLanguageFactory(
     if (trailingSlash)
       xDefaultHref = ensureSuffix('/', xDefaultHref)
 
-    const links: XHTMLanguageLink[] = locales.map((l) => {
+    const links: XHTMLanguageLink[] = [{
+      hreflang: defaultLanguage,
+      rel: 'alternate',
+      href: xDefaultHref,
+    }]
+
+    for (const l of locales) {
       const href = new URL(`${useBasePath}${l}/${pathWithoutLang}`, hostNamePath).href
-      return {
+      links.push({
         hreflang: l,
         rel: 'alternate',
         href: trailingSlash ? ensureSuffix('/', href) : href,
-      }
-    }).concat({
-      hreflang: 'x-default',
-      rel: 'alternate',
-      href: xDefaultHref,
-    })
+      })
+    }
 
-    links.unshift({
-      hreflang: defaultLanguage,
+    links.push({
+      hreflang: 'x-default',
       rel: 'alternate',
       href: xDefaultHref,
     })

--- a/src/sitemap.ts
+++ b/src/sitemap.ts
@@ -40,7 +40,7 @@ export function getFormattedSitemap(options: ResolvedOptions, routes: string[]) 
     return routes.map(prefixExceptDefaultLanguageFactory(
       options,
       {
-        defaultLanguage: options.i18n.defaultLanguage ?? 'en',
+        defaultLanguage: options.i18n.defaultLanguage || 'en',
         languages: options.i18n.languages,
       },
     ))

--- a/src/sitemap.ts
+++ b/src/sitemap.ts
@@ -107,7 +107,7 @@ function prefixExceptDefaultLanguageFactory(
     let pathWithoutLang: string
     if (route === useBasePath) {
       url = ensureSuffix('/', new URL(useBasePath, hostNamePath).href)
-      pathWithoutLang = useBasePath[0] === '/' ? useBasePath.slice(1) : useBasePath
+      pathWithoutLang = ''
     }
     else {
       const locale = localePrefixes.find(([
@@ -120,7 +120,7 @@ function prefixExceptDefaultLanguageFactory(
           ? route.replace(locale[0], '')
           : route.replace(locale[1], '')
         if (url === '') {
-          pathWithoutLang = useBasePath.slice(1)
+          pathWithoutLang = ''
           url = ensureSuffix('/', new URL(`${useBasePath}${locale[2]}`, hostNamePath).href)
         }
         else {

--- a/src/sitemap.ts
+++ b/src/sitemap.ts
@@ -96,7 +96,7 @@ function prefixExceptDefaultLanguageFactory(
   const hostNamePath = removeMaybeSuffix('/', options.hostname)
   const useBasePath = ensurePrefix('/', ensureSuffix('/', options.basePath))
   const contextPath = removeMaybeSuffix('/', useBasePath)
-  const defaultLanguage = i18n.defaultLanguage ?? 'en'
+  const defaultLanguage = i18n.defaultLanguage || 'en'
   const locales = i18n.languages.filter(l => l !== defaultLanguage)
   const localePrefixes = locales.map((lang) => {
     return [`${contextPath}/${lang}/`, `${contextPath}/${lang}`, lang] as const

--- a/src/sitemap.ts
+++ b/src/sitemap.ts
@@ -1,5 +1,5 @@
 import { join, parse } from 'node:path'
-import { ensurePrefix, slash } from '@antfu/utils'
+import { ensurePrefix, ensureSuffix, slash } from '@antfu/utils'
 import fg from 'fast-glob'
 
 import type { ResolvedOptions, RoutesOptionMap } from './types'
@@ -36,6 +36,15 @@ function getOptionByRoute<T extends Date | string | number>(options: T | RoutesO
 }
 
 export function getFormattedSitemap(options: ResolvedOptions, routes: string[]) {
+  if (options.i18n?.strategy === 'prefix_except_default') {
+    return routes.map(prefixExceptDefaultLanguageFactory(
+      options,
+      {
+        defaultLanguage: options.i18n.defaultLanguage ?? 'en',
+        languages: options.i18n.languages,
+      },
+    ))
+  }
   return routes.map((route) => {
     const hostNamePath = removeMaybeSuffix('/', options.hostname)
     const routePath = options.basePath ? ensurePrefix('/', options.basePath) + ensurePrefix('/', route) : ensurePrefix('/', route)
@@ -57,4 +66,103 @@ export function getFormattedSitemap(options: ResolvedOptions, routes: string[]) 
 
     return formattedSitemap
   })
+}
+
+interface PrefixExceptDefaultStrategy {
+  defaultLanguage: string
+  languages: string[]
+}
+
+interface XHTMLanguageLink {
+  hreflang: string
+  rel: string
+  href: string
+}
+
+interface SiteMapRouteEntry {
+  url: string
+  changefreq?: string
+  priority?: number
+  lastmod?: Date | string | number
+  links: XHTMLanguageLink[]
+}
+
+function prefixExceptDefaultLanguageFactory(
+  options: ResolvedOptions,
+  i18n: PrefixExceptDefaultStrategy,
+) {
+  // we need N links, where N is the number of languages, the x-default should always use the default language link for the target route
+  // we also need to handle special / cases like /en, /fr, etc. We need to ensure that the loc and xhtml:link always with the trailing /
+  const hostNamePath = removeMaybeSuffix('/', options.hostname)
+  const useBasePath = ensurePrefix('/', ensureSuffix('/', options.basePath))
+  const contextPath = removeMaybeSuffix('/', useBasePath)
+  const defaultLanguage = i18n.defaultLanguage ?? 'en'
+  const locales = i18n.languages.filter(l => l !== defaultLanguage)
+  const localePrefixes = locales.map((lang) => {
+    return [`${contextPath}/${lang}/`, `${contextPath}/${lang}`, lang] as const
+  })
+
+  return (route: string) => {
+    let url: string
+    let pathWithoutLang: string
+    if (route === useBasePath) {
+      url = ensureSuffix('/', new URL(useBasePath, hostNamePath).href)
+      pathWithoutLang = useBasePath[0] === '/' ? useBasePath.slice(1) : useBasePath
+    }
+    else {
+      const locale = localePrefixes.find(([
+        prefix1,
+        prefix2,
+      ]) => route.startsWith(prefix1) || route.startsWith(prefix2),
+      )
+      if (locale) {
+        url = route.startsWith(locale[0])
+          ? route.replace(locale[0], '')
+          : route.replace(locale[1], '')
+        if (url === '') {
+          pathWithoutLang = useBasePath[0] === '/' ? useBasePath.slice(1) : useBasePath
+          url = ensureSuffix('/', new URL(`${useBasePath}${locale[2]}`, hostNamePath).href)
+        }
+        else {
+          pathWithoutLang = url.replace(useBasePath, '')
+          url = new URL(route, hostNamePath).href
+        }
+      }
+      else {
+        pathWithoutLang = route.replace(useBasePath, '')
+        url = new URL(route, hostNamePath).href
+      }
+    }
+    const trailingSlash = url.at(-1) === '/'
+    let xDefaultHref = new URL(`${useBasePath}${pathWithoutLang}`, hostNamePath).href
+    if (trailingSlash)
+      xDefaultHref = ensureSuffix('/', xDefaultHref)
+
+    const links: XHTMLanguageLink[] = locales.map((l) => {
+      const href = new URL(`${useBasePath}${l}/${pathWithoutLang}`, hostNamePath).href
+      return {
+        hreflang: l,
+        rel: 'alternate',
+        href: trailingSlash ? ensureSuffix('/', href) : href,
+      }
+    }).concat({
+      hreflang: 'x-default',
+      rel: 'alternate',
+      href: xDefaultHref,
+    })
+
+    links.unshift({
+      hreflang: defaultLanguage,
+      rel: 'alternate',
+      href: xDefaultHref,
+    })
+
+    return {
+      url,
+      changefreq: getOptionByRoute(options.changefreq, route) ?? defaultOptions.changefreq,
+      priority: getOptionByRoute(options.priority, route) ?? defaultOptions.priority,
+      lastmod: getOptionByRoute(options.lastmod, route) ?? defaultOptions.lastmod,
+      links,
+    } satisfies SiteMapRouteEntry
+  }
 }

--- a/src/sitemap.ts
+++ b/src/sitemap.ts
@@ -91,7 +91,7 @@ function prefixExceptDefaultLanguageFactory(
   options: ResolvedOptions,
   i18n: PrefixExceptDefaultStrategy,
 ) {
-  // we need N links, where N is the number of languages, the x-default should always use the default language link for the target route
+  // we need N + 1 links, where N is the number of languages + x-default, the x-default should always use the default language link for the target route
   // we also need to handle special / cases like /en, /fr, etc. We need to ensure that the loc and xhtml:link always with the trailing /
   const hostNamePath = removeMaybeSuffix('/', options.hostname)
   const useBasePath = ensurePrefix('/', ensureSuffix('/', options.basePath))

--- a/src/sitemap.ts
+++ b/src/sitemap.ts
@@ -76,14 +76,14 @@ interface PrefixExceptDefaultStrategy {
 interface XHTMLanguageLink {
   hreflang: string
   rel: string
-  href: string
+  url: string
 }
 
 interface SiteMapRouteEntry {
   url: string
   changefreq?: string
   priority?: number
-  lastmod?: Date | string | number
+  lastmod?: Date
   links: XHTMLanguageLink[]
 }
 
@@ -141,7 +141,7 @@ function prefixExceptDefaultLanguageFactory(
     const links: XHTMLanguageLink[] = [{
       hreflang: defaultLanguage,
       rel: 'alternate',
-      href: xDefaultHref,
+      url: xDefaultHref,
     }]
 
     for (const l of locales) {
@@ -149,14 +149,14 @@ function prefixExceptDefaultLanguageFactory(
       links.push({
         hreflang: l,
         rel: 'alternate',
-        href: trailingSlash ? ensureSuffix('/', href) : href,
+        url: trailingSlash ? ensureSuffix('/', href) : href,
       })
     }
 
     links.push({
       hreflang: 'x-default',
       rel: 'alternate',
-      href: xDefaultHref,
+      url: xDefaultHref,
     })
 
     return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,7 +63,7 @@ interface Options {
   i18n?: {
     defaultLanguage?: string
     languages: string[]
-    strategy?: 'suffix' | 'prefix'
+    strategy?: 'suffix' | 'prefix' | 'prefix_except_default'
   }
   /**
    * Other sitemaps paths

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,4 +1,4 @@
-import { existsSync, rmSync, rmdirSync } from 'node:fs'
+import { existsSync, rmSync } from 'node:fs'
 import { afterEach, beforeEach } from 'vitest'
 
 import { ROBOTS_FILE, SITEMAP_FILE, SUBPATH_FOLDER, TEST_FILES } from './variables'
@@ -13,7 +13,7 @@ function removeFiles() {
       rmSync(testFile)
   })
   if (existsSync(SUBPATH_FOLDER))
-    rmdirSync(SUBPATH_FOLDER, { recursive: true })
+    rmSync(SUBPATH_FOLDER, { recursive: true, force: true })
 }
 
 beforeEach(() => {

--- a/test/sitemap.test.ts
+++ b/test/sitemap.test.ts
@@ -258,5 +258,108 @@ describe('sitemap', () => {
         },
       ]
     `)
+    expect(getFormattedSitemap(resolveOptions({
+      i18n: {
+        languages: ['fr', 'en'],
+        defaultLanguage: 'fr',
+        strategy: 'prefix_except_default',
+      },
+      lastmod: new Date('2025-07-18T12:00:00.00Z'),
+    }), ['/', '/route-a', '/en/', '/en/route-a'])).toMatchInlineSnapshot(`
+      [
+        {
+          "changefreq": "daily",
+          "lastmod": 2025-07-18T12:00:00.000Z,
+          "links": [
+            {
+              "href": "http://localhost/",
+              "hreflang": "fr",
+              "rel": "alternate",
+            },
+            {
+              "href": "http://localhost/en/",
+              "hreflang": "en",
+              "rel": "alternate",
+            },
+            {
+              "href": "http://localhost/",
+              "hreflang": "x-default",
+              "rel": "alternate",
+            },
+          ],
+          "priority": 1,
+          "url": "http://localhost/",
+        },
+        {
+          "changefreq": "daily",
+          "lastmod": 2025-07-18T12:00:00.000Z,
+          "links": [
+            {
+              "href": "http://localhost/route-a",
+              "hreflang": "fr",
+              "rel": "alternate",
+            },
+            {
+              "href": "http://localhost/en/route-a",
+              "hreflang": "en",
+              "rel": "alternate",
+            },
+            {
+              "href": "http://localhost/route-a",
+              "hreflang": "x-default",
+              "rel": "alternate",
+            },
+          ],
+          "priority": 1,
+          "url": "http://localhost/route-a",
+        },
+        {
+          "changefreq": "daily",
+          "lastmod": 2025-07-18T12:00:00.000Z,
+          "links": [
+            {
+              "href": "http://localhost/",
+              "hreflang": "fr",
+              "rel": "alternate",
+            },
+            {
+              "href": "http://localhost/en/",
+              "hreflang": "en",
+              "rel": "alternate",
+            },
+            {
+              "href": "http://localhost/",
+              "hreflang": "x-default",
+              "rel": "alternate",
+            },
+          ],
+          "priority": 1,
+          "url": "http://localhost/en/",
+        },
+        {
+          "changefreq": "daily",
+          "lastmod": 2025-07-18T12:00:00.000Z,
+          "links": [
+            {
+              "href": "http://localhost/route-a",
+              "hreflang": "fr",
+              "rel": "alternate",
+            },
+            {
+              "href": "http://localhost/en/route-a",
+              "hreflang": "en",
+              "rel": "alternate",
+            },
+            {
+              "href": "http://localhost/route-a",
+              "hreflang": "x-default",
+              "rel": "alternate",
+            },
+          ],
+          "priority": 1,
+          "url": "http://localhost/en/route-a",
+        },
+      ]
+    `)
   })
 })

--- a/test/sitemap.test.ts
+++ b/test/sitemap.test.ts
@@ -264,7 +264,7 @@ describe('sitemap', () => {
         defaultLanguage: 'fr',
         strategy: 'prefix_except_default',
       },
-      lastmod: new Date('2025-07-18T12:00:00.00Z'),
+      lastmod: new Date('2025-07-18T12:00:00.000Z'),
     }), ['/', '/route-a', '/en/', '/en/route-a'])).toMatchInlineSnapshot(`
       [
         {

--- a/test/sitemap.test.ts
+++ b/test/sitemap.test.ts
@@ -272,19 +272,19 @@ describe('sitemap', () => {
           "lastmod": 2025-07-18T12:00:00.000Z,
           "links": [
             {
-              "href": "http://localhost/",
               "hreflang": "fr",
               "rel": "alternate",
+              "url": "http://localhost/",
             },
             {
-              "href": "http://localhost/en/",
               "hreflang": "en",
               "rel": "alternate",
+              "url": "http://localhost/en/",
             },
             {
-              "href": "http://localhost/",
               "hreflang": "x-default",
               "rel": "alternate",
+              "url": "http://localhost/",
             },
           ],
           "priority": 1,
@@ -295,19 +295,19 @@ describe('sitemap', () => {
           "lastmod": 2025-07-18T12:00:00.000Z,
           "links": [
             {
-              "href": "http://localhost/route-a",
               "hreflang": "fr",
               "rel": "alternate",
+              "url": "http://localhost/route-a",
             },
             {
-              "href": "http://localhost/en/route-a",
               "hreflang": "en",
               "rel": "alternate",
+              "url": "http://localhost/en/route-a",
             },
             {
-              "href": "http://localhost/route-a",
               "hreflang": "x-default",
               "rel": "alternate",
+              "url": "http://localhost/route-a",
             },
           ],
           "priority": 1,
@@ -318,19 +318,19 @@ describe('sitemap', () => {
           "lastmod": 2025-07-18T12:00:00.000Z,
           "links": [
             {
-              "href": "http://localhost/",
               "hreflang": "fr",
               "rel": "alternate",
+              "url": "http://localhost/",
             },
             {
-              "href": "http://localhost/en/",
               "hreflang": "en",
               "rel": "alternate",
+              "url": "http://localhost/en/",
             },
             {
-              "href": "http://localhost/",
               "hreflang": "x-default",
               "rel": "alternate",
+              "url": "http://localhost/",
             },
           ],
           "priority": 1,
@@ -341,19 +341,19 @@ describe('sitemap', () => {
           "lastmod": 2025-07-18T12:00:00.000Z,
           "links": [
             {
-              "href": "http://localhost/route-a",
               "hreflang": "fr",
               "rel": "alternate",
+              "url": "http://localhost/route-a",
             },
             {
-              "href": "http://localhost/en/route-a",
               "hreflang": "en",
               "rel": "alternate",
+              "url": "http://localhost/en/route-a",
             },
             {
-              "href": "http://localhost/route-a",
               "hreflang": "x-default",
               "rel": "alternate",
+              "url": "http://localhost/route-a",
             },
           ],
           "priority": 1,


### PR DESCRIPTION
This PR also fixes the cleanup test setup, we can use rmSync with force set to true.

Added some internal types, we can remove them or reuse them in the rest of the logic: using satisfies and so no types returned, just the shape.

**NOTE**: I need to check how file names are mapped, maybe tmr with a local tgz from this PR in my i18n project.

**NOTE**: you should avoid generating html test files in the dist folder, create a folder for that and use it.